### PR TITLE
Demoonstrate that changing the servlet context path via Spring Boot works.

### DIFF
--- a/basics/src/main/resources/application.properties
+++ b/basics/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.servlet.context-path=/ctx


### PR DESCRIPTION
When applying `server.servlet.context-path=/ctx`, the links automatically adjust.

```
2020-04-13 10:43:59.877  INFO 79416 --- [  restartedMain] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat started on port(s): 8080 (http) with context path '/ctx'
```

Testing with curl...

```
$ curl localhost:8080/ctx/employees | jq
{
  "_embedded": {
    "employees": [
      {
        "id": 1,
        "firstName": "Frodo",
        "lastName": "Baggins",
        "role": "ring bearer",
        "fullName": "Frodo Baggins",
        "_links": {
          "self": {
            "href": "http://localhost:8080/ctx/employees/1"
          },
          "employees": {
            "href": "http://localhost:8080/ctx/employees"
          }
        }
      },
      {
        "id": 2,
        "firstName": "Bilbo",
        "lastName": "Baggins",
        "role": "burglar",
        "fullName": "Bilbo Baggins",
        "_links": {
          "self": {
            "href": "http://localhost:8080/ctx/employees/2"
          },
          "employees": {
            "href": "http://localhost:8080/ctx/employees"
          }
        }
      }
    ]
  },
  "_links": {
    "self": {
      "href": "http://localhost:8080/ctx/employees"
    }
  }
}
```