### PR TITLE
Fixed NullPointException bug when SupervisorController query is invalid

### DIFF
--- a/hypermedia/src/main/java/org/springframework/hateoas/examples/SupervisorController.java
+++ b/hypermedia/src/main/java/org/springframework/hateoas/examples/SupervisorController.java
@@ -41,10 +41,12 @@ public class SupervisorController {
 
 		EntityModel<Manager> managerResource = controller.findOne(id).getBody();
 
-		EntityModel<Supervisor> supervisorResource = EntityModel.of( //
-				new Supervisor(managerResource.getContent()), //
-				managerResource.getLinks());
-
-		return ResponseEntity.ok(supervisorResource);
+		if (managerResource != null) {
+			EntityModel<Supervisor> supervisorResource = EntityModel.of( //
+					new Supervisor(managerResource.getContent()), //
+					managerResource.getLinks());
+			return ResponseEntity.ok(supervisorResource);
+		}
+		return ResponseEntity.notFound().build();
 	}
 }


### PR DESCRIPTION
I fixed a bug that “When I query with ‘supervisor /{id}’ in  'SupervisorController', because the manager is not exist, then happened NullPointException”